### PR TITLE
Adding et, ae, and irb interfaces to junos

### DIFF
--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
@@ -54,8 +54,12 @@ class InterfaceConfig(Parser):
     def type(self) -> Optional[str]:
         if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et", "fxp"]]):
             return "iana-if-type:ethernetCsmacd"
-        elif any([self.yy.key.startswith(prefix) for prefix in ["lo", "ae", "irb"]]):
+        elif self.yy.key.startswith("lo"):
             return "iana-if-type:softwareLoopback"
+        elif self.yy.key.startswith("ae"):
+            return "iana-if-type:ieee8023adLag"
+        elif self.yy.key.startswith("irb"):
+            return "iana-if-type:l3ipvlan"
         else:
             raise Exception(f"don't know the type for {self.yy.key}")
 

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
@@ -52,9 +52,9 @@ class InterfaceConfig(Parser):
         return cast(str, self.yy.key)
 
     def type(self) -> Optional[str]:
-        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe"]]):
+        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et"]]):
             return "iana-if-type:ethernetCsmacd"
-        elif self.yy.key.startswith("lo"):
+        elif any([self.yy.key.startswith(prefix) for prefix in ["lo", "ae", "irb"]]):
             return "iana-if-type:softwareLoopback"
         else:
             raise Exception(f"don't know the type for {self.yy.key}")

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
@@ -52,7 +52,9 @@ class InterfaceConfig(Parser):
         return cast(str, self.yy.key)
 
     def type(self) -> Optional[str]:
-        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et", "fxp"]]):
+        if any(
+            [self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et", "fxp"]]
+        ):
             return "iana-if-type:ethernetCsmacd"
         elif self.yy.key.startswith("lo"):
             return "iana-if-type:softwareLoopback"

--- a/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/dev_conf
+++ b/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/dev_conf
@@ -24,5 +24,45 @@
                     <name>0</name>
                 </unit>
             </interface>
+            <interface>
+                <name>et-0/0/48</name>
+            </interface>
+            <interface>
+                <name>irb</name>
+                <unit>
+                    <name>0</name>
+                </unit>
+                <unit>
+                    <name>301</name>
+                    <family>
+                        <inet>
+                            <address>
+                                <name>192.168.255.1/24</name>
+                            </address>
+                        </inet>
+                    </family>
+                </unit>
+            </interface>
+            <interface>
+                <name>ae16</name>
+                <description>Some port name</description>
+                <mtu>9156</mtu>
+                <aggregated-ether-options>
+                    <lacp>
+                        <active/>
+                    </lacp>
+                </aggregated-ether-options>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <inet>
+                            <no-redirects/>
+                            <address>
+                                <name>10.1.1.1/24</name>
+                            </address>
+                        </inet>
+                    </family>
+                </unit>
+            </interface>
         </interfaces>
 </configuration>

--- a/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/result.json
+++ b/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/result.json
@@ -75,7 +75,7 @@
         "name": "irb",
         "config": {
           "name": "irb",
-          "type": "iana-if-type:softwareLoopback",
+          "type": "iana-if-type:l3ipvlan",
           "enabled": true
         },
         "subinterfaces": {
@@ -99,7 +99,7 @@
         "name": "ae16",
         "config": {
           "name": "ae16",
-          "type": "iana-if-type:softwareLoopback",
+          "type": "iana-if-type:ieee8023adLag",
           "enabled": true
         },
         "subinterfaces": {

--- a/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/result.json
+++ b/tests/models/openconfig/data/openconfig-interfaces/parse/junos/config/result.json
@@ -62,6 +62,56 @@
             }
           ]
         }
+      },
+      {
+        "name": "et-0/0/48",
+        "config": {
+          "name": "et-0/0/48",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": true
+        }
+      },
+      {
+        "name": "irb",
+        "config": {
+          "name": "irb",
+          "type": "iana-if-type:softwareLoopback",
+          "enabled": true
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0
+              }
+            },
+            {
+              "index": 301,
+              "config": {
+                "index": 301
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "ae16",
+        "config": {
+          "name": "ae16",
+          "type": "iana-if-type:softwareLoopback",
+          "enabled": true
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0
+              }
+            }
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
I looked at one of our switches, and it shows the `ae` and `irb` interfaces as loopbacks, so I hope software loopback is the appropriate iana-if-type.  `et` is a 40G physical.

```
show interfaces irb snmp-index 0                                                                                                                                                                                                  
Physical interface: .local., Enabled, Physical link is Up                                                                                                                                                                                                
  Interface index: 0, SNMP ifIndex: 0                                                                                                                                                                                                                    
  Type: Loopback, Link-level type: Interface-Specific, MTU: Unlimited, Speed: Unlimited
```