### PR TITLE
Junos allow named vlan

### DIFF
--- a/ntc_rosetta/parsers/openconfig/junos/helpers.py
+++ b/ntc_rosetta/parsers/openconfig/junos/helpers.py
@@ -1,0 +1,14 @@
+"""Helper for junos parsers"""
+from typing import List
+
+
+def resolve_vlan_ids(vlans: List, root) -> List[int]:
+    """Resolve named vlans from /configuration/vlans/vlan path"""
+    rv = list()
+    for vlan in vlans:
+        elem = root["dev_conf"].xpath(
+            "//vlan[name/text()='{member}']/vlan-id".format(member=vlan.text)
+        )
+        if elem is not None:
+            rv.append(int(elem[0].text))
+    return rv

--- a/ntc_rosetta/parsers/openconfig/junos/helpers.py
+++ b/ntc_rosetta/parsers/openconfig/junos/helpers.py
@@ -6,6 +6,9 @@ def resolve_vlan_ids(vlans: List, root) -> List[int]:
     """Resolve named vlans from /configuration/vlans/vlan path"""
     rv = list()
     for vlan in vlans:
+        if vlan.text.isnumeric():
+            rv.append(int(vlan.text))
+            continue
         elem = root["dev_conf"].xpath(
             "//vlan[name/text()='{member}']/vlan-id".format(member=vlan.text)
         )

--- a/ntc_rosetta/parsers/openconfig/junos/helpers.py
+++ b/ntc_rosetta/parsers/openconfig/junos/helpers.py
@@ -9,6 +9,6 @@ def resolve_vlan_ids(vlans: List, root) -> List[int]:
         elem = root["dev_conf"].xpath(
             "//vlan[name/text()='{member}']/vlan-id".format(member=vlan.text)
         )
-        if elem is not None:
+        if elem is not None and len(elem):
             rv.append(int(elem[0].text))
     return rv

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
@@ -52,9 +52,9 @@ class InterfaceConfig(Parser):
         return cast(str, self.yy.key)
 
     def type(self) -> Optional[str]:
-        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe"]]):
+        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et"]]):
             return "iana-if-type:ethernetCsmacd"
-        elif self.yy.key.startswith("lo"):
+        elif any([self.yy.key.startswith(prefix) for prefix in ["lo", "ae", "irb"]]):
             return "iana-if-type:softwareLoopback"
         else:
             raise Exception(f"don't know the type for {self.yy.key}")

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_interfaces/interfaces.py
@@ -52,9 +52,9 @@ class InterfaceConfig(Parser):
         return cast(str, self.yy.key)
 
     def type(self) -> Optional[str]:
-        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "et"]]):
+        if any([self.yy.key.startswith(prefix) for prefix in ["ge", "xe", "fxp"]]):
             return "iana-if-type:ethernetCsmacd"
-        elif any([self.yy.key.startswith(prefix) for prefix in ["lo", "ae", "irb"]]):
+        elif self.yy.key.startswith("lo"):
             return "iana-if-type:softwareLoopback"
         else:
             raise Exception(f"don't know the type for {self.yy.key}")

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/switched_vlan.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/switched_vlan.py
@@ -29,7 +29,7 @@ class SwitchedVlanConfig(Parser):
                 "unit[name=0]/family/ethernet-switching/vlan/members"
             )
             vlan_ids = resolve_vlan_ids(vlans, self.yy.root_native)
-            if vlans:
+            if vlan_ids:
                 return vlan_ids[0]
         return None
 
@@ -39,7 +39,7 @@ class SwitchedVlanConfig(Parser):
                 "unit[name=0]/family/ethernet-switching/vlan/members"
             )
             vlan_ids = resolve_vlan_ids(vlans, self.yy.root_native)
-            if vlans:
+            if vlan_ids:
                 return vlan_ids
         return None
 

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/switched_vlan.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/switched_vlan.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, cast
 
 from yangify.parser import Parser, ParserData
+from ntc_rosetta.parsers.openconfig.junos.helpers import resolve_vlan_ids
 
 
 class SwitchedVlanConfig(Parser):
@@ -24,11 +25,12 @@ class SwitchedVlanConfig(Parser):
 
     def access_vlan(self) -> Optional[int]:
         if self.yy._interface_mode() == "ACCESS":
-            vlan = self.yy.native.xpath(
+            vlans = self.yy.native.xpath(
                 "unit[name=0]/family/ethernet-switching/vlan/members"
             )
-            if vlan:
-                return int(vlan[0].text)
+            vlan_ids = resolve_vlan_ids(vlans, self.yy.root_native)
+            if vlans:
+                return vlan_ids[0]
         return None
 
     def trunk_vlans(self) -> Optional[List[str]]:
@@ -36,8 +38,9 @@ class SwitchedVlanConfig(Parser):
             vlans = self.yy.native.xpath(
                 "unit[name=0]/family/ethernet-switching/vlan/members"
             )
+            vlan_ids = resolve_vlan_ids(vlans, self.yy.root_native)
             if vlans:
-                return [v.text for v in vlans]
+                return vlan_ids
         return None
 
 

--- a/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/vlans.py
+++ b/ntc_rosetta/parsers/openconfig/junos/openconfig_vlan/vlans.py
@@ -28,7 +28,11 @@ class Vlan(Parser):
 
         def extract_elements(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
             for i in self.native.xpath("/configuration/vlans/vlan"):
-                yield i.findtext("vlan-id"), i
+                elem = i.findtext("vlan-id")
+                if elem is None:
+                    # QFX configuration may not contain vlan-id tag
+                    continue
+                yield elem, i
 
     config = VlanConfig
 

--- a/tests/models/openconfig/data/openconfig-vlan/parse/junos/config/dev_conf
+++ b/tests/models/openconfig/data/openconfig-vlan/parse/junos/config/dev_conf
@@ -36,6 +36,35 @@
                     </family>
                 </unit>
             </interface>
+            <interface>
+                <name>xe-0/0/4</name>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <ethernet-switching>
+                            <interface-mode>trunk</interface-mode>
+                            <vlan>
+                                <members>VLAN-100</members>
+                                <members>VLAN-200</members>
+                            </vlan>
+                        </ethernet-switching>
+                    </family>
+                </unit>
+            </interface>
+            <interface>
+                <name>xe-0/0/5</name>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <ethernet-switching>
+                            <interface-mode>access</interface-mode>
+                            <vlan>
+                                <members>VLAN-100</members>
+                            </vlan>
+                        </ethernet-switching>
+                    </family>
+                </unit>
+            </interface>
         </interfaces>
     <vlans>
             <vlan>
@@ -48,6 +77,14 @@
             </vlan>
             <vlan inactive="inactive">
                 <vlan-id>10</vlan-id>
+            </vlan>
+            <vlan>
+                <name>VLAN-100</name>
+                <vlan-id>100</vlan-id>
+            </vlan>
+            <vlan>
+                <name>VLAN-200</name>
+                <vlan-id>200</vlan-id>
             </vlan>
     </vlans>
 </configuration>

--- a/tests/models/openconfig/data/openconfig-vlan/parse/junos/config/result.json
+++ b/tests/models/openconfig/data/openconfig-vlan/parse/junos/config/result.json
@@ -74,6 +74,61 @@
             }
           }
         }
+      },
+      {
+        "name": "xe-0/0/4",
+        "config": {
+          "name": "xe-0/0/4",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": true
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "interface-mode": "TRUNK",
+              "trunk-vlans": [
+                100,
+                200
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "xe-0/0/5",
+        "config": {
+          "name": "xe-0/0/5",
+          "type": "iana-if-type:ethernetCsmacd",
+          "enabled": true
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "openconfig-vlan:switched-vlan": {
+            "config": {
+              "interface-mode": "ACCESS",
+              "access-vlan": 100
+            }
+          }
+        }
       }
     ]
   },
@@ -107,6 +162,22 @@
               "config": {
                 "vlan-id": 10,
                 "status": "SUSPENDED"
+              }
+            },
+            {
+              "vlan-id": 100,
+              "config": {
+                "vlan-id": 100,
+                "name": "VLAN-100",
+                "status": "ACTIVE"
+              }
+            },
+            {
+              "vlan-id": 200,
+              "config": {
+                "vlan-id": 200,
+                "name": "VLAN-200",
+                "status": "ACTIVE"
               }
             }
           ]


### PR DESCRIPTION
The current parser cannot handle vlans with no `vlan-id` and "named" vlans under the interface config.  This PR adds a check for empty `vlan-id` tags and performs a lookup to map vlan-id to named vlans.
```
            <interface>
                <name>xe-0/0/1</name>
                <flexible-vlan-tagging/>
                <unit>
                    <name>0</name>
                    <family>
                        <ethernet-switching>
                            <interface-mode>trunk</interface-mode>
                            <vlan>
                                <members>VXLAN-1001</members>
                            </vlan>
                        </ethernet-switching>
                    </family>
                </unit>
            </interface>
...
            <vlan>
                <name>RECIRC-VXLAN-1000</name>
                <interface>
                    <name>xe-0/0/1.3</name>
                </interface>
                <interface>
                    <name>ae67.3</name>
                </interface>
            </vlan>
            <vlan>
                <name>VXLAN-1001</name>
                <vlan-id>1001</vlan-id>
                <vxlan>
                    <vni>1001</vni>
                    <ingress-node-replication/>
                </vxlan>
            </vlan>
```