### PR TITLE
load datamodels once and only once and only when/if needed

### DIFF
--- a/ntc_rosetta/drivers/ios.py
+++ b/ntc_rosetta/drivers/ios.py
@@ -3,16 +3,15 @@ from ntc_rosetta.parsers.ntc.ios import NTCParser as NTCIOSParser
 from ntc_rosetta.parsers.openconfig.ios import IOSParser as OCIOSParser
 from ntc_rosetta.translators.ntc.ios import NTCTranslator as NTCIOSTranslator
 from ntc_rosetta.translators.openconfig.ios import IOSTranslator as OCIOSTranslator
-from ntc_rosetta.yang import get_data_model
 
 
 class IOSDriverOpenconfig(Driver):
     parser = OCIOSParser
     translator = OCIOSTranslator
-    datamodel = get_data_model("openconfig")
+    datamodel_name = "openconfig"
 
 
 class IOSDriverNTC(Driver):
     parser = NTCIOSParser
     translator = NTCIOSTranslator
-    datamodel = get_data_model("ntc")
+    datamodel_name = "ntc"

--- a/ntc_rosetta/drivers/junos.py
+++ b/ntc_rosetta/drivers/junos.py
@@ -5,16 +5,15 @@ from ntc_rosetta.translators.ntc.junos import JunosTranslator as NTCJunosTransla
 from ntc_rosetta.translators.openconfig.junos import (
     JunosTranslator as OCJunosTranslator,
 )
-from ntc_rosetta.yang import get_data_model
 
 
 class JunosDriverOpenconfig(Driver):
     parser = OCJunosParser
     translator = OCJunosTranslator
-    datamodel = get_data_model("openconfig")
+    datamodel_name = "openconfig"
 
 
 class JunosDriverNTC(Driver):
     parser = NTCJunosParser
     translator = NTCJunosTranslator
-    datamodel = get_data_model("ntc")
+    datamodel_namw = "ntc"

--- a/ntc_rosetta/yang/__init__.py
+++ b/ntc_rosetta/yang/__init__.py
@@ -2,6 +2,7 @@ import pathlib
 
 from yangson.datamodel import DataModel
 
+_DATAMODELS = {"openconfig": None, "ntc": None}
 
 BASEPATH = pathlib.Path(__file__).parent
 OPENCONFIG_LIB = f"{BASEPATH}/openconfig.json"
@@ -50,9 +51,13 @@ def get_data_model(model: str = "openconfig") -> DataModel:
     Returns an instantiated data model.
     """
     if model == "openconfig":
-        return _get_openconfig_data_model()
+        if _DATAMODELS["openconfig"] is None:
+            _DATAMODELS["openconfig"] = _get_openconfig_data_model()
+        return _DATAMODELS["openconfig"]
     elif model == "ntc":
-        return _get_ntc_data_model()
+        if _DATAMODELS["ntc"] is None:
+            _DATAMODELS["ntc"] = _get_ntc_data_model()
+        return _DATAMODELS["ntc"]
     else:
         raise ValueError(f"model {model} not recognized")
 


### PR DESCRIPTION
Before we would:

1. Load a datamodel per driver
2. Load all datamodels when loading ntc-rosetta

this lead to (a) wasting memory (b) wasting initialization time.

Now we:

1. Load each datamodel once and only once, regardless of how many drivers use the same datamodel.
2. Load datamodels when/if needed