### PR TITLE
BugFix: ios - oc-vlan - vlan internal config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 __pycache__
+.mypy_cache
 .coverage
 _build
 .ipynb_checkpoints

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM python:${PYTHON}-stretch
 
 RUN apt-get update && apt-get install -y pandoc
 
-RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python && \
-    /root/.poetry/bin/poetry config settings.virtualenvs.create false && ln -sf /root/.poetry/bin/poetry /usr/local/bin/poetry
+RUN pip install poetry==1.0.0 && poetry config virtualenvs.create false && pip install -U "pip<19"
 
 ADD poetry.lock /tmp
 ADD pyproject.toml /tmp

--- a/ntc_rosetta/parsers/openconfig/ios/openconfig_vlan/vlans.py
+++ b/ntc_rosetta/parsers/openconfig/ios/openconfig_vlan/vlans.py
@@ -34,6 +34,11 @@ class Vlan(Parser):
 
         def extract_elements(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
             for k, v in jh.query("vlan", self.native, default={}).items():
+                try:
+                    int(k)
+                except ValueError:
+                    continue
+
                 if k == "#text":
                     continue
                 yield k, cast(Dict[str, Any], v)


### PR DESCRIPTION
Fixes #23 

This is just a generic fix. If we think there is a better way, we can definitely do that. This basically checks to see if the vlan can be converted into an integer, if not, it does not yield the results.

I did it this way as there are a few config options pointed out by @dgjustice in the issue and the valid options should be able to be converted into integers within the oc-vlan model.