### PR TITLE
Pin Sphinx version to not hit 'duplicate object description'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:${PYTHON}-stretch
 
 RUN apt-get update && apt-get install -y pandoc
 
-RUN pip install poetry==1.0.0 && poetry config virtualenvs.create false && pip install -U "pip<19"
+RUN pip install poetry==1.0.0 && poetry config virtualenvs.create false && pip install -U pip
 
 ADD poetry.lock /tmp
 ADD pyproject.toml /tmp

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<3.0.0
 sphinx_rtd_theme
 sphinxcontrib-napoleon
 nbsphinx


### PR DESCRIPTION
Simply pining Sphinx version to unblock CI pipeline

Similar to https://github.com/networktocode/yangify/pull/36/commits/e9cb7170ecf434fa714aaacc90afe6ccf5411264